### PR TITLE
feat: add bus info webview pages

### DIFF
--- a/docs/flutter-integration.md
+++ b/docs/flutter-integration.md
@@ -1,0 +1,158 @@
+# Flutter ↔ Webview 연동 가이드
+
+## 1. 개요
+
+웹뷰 페이지에서 네이티브 기능(전화 걸기, 지도 앱 열기 등)이 필요할 때, JavaScript 메시지 채널을 통해 Flutter에 요청을 보낸다.
+
+```
+[웹뷰 (React)]                        [Flutter]
+flutterCommunicate(url)
+  → customwebviewmessage.postMessage(url)  →  onMessageReceived
+                                                → canLaunchUrl(url)
+                                                → launchUrl(url)
+```
+
+## 2. 통신 채널
+
+### `customwebviewmessage`
+
+웹뷰에서 Flutter로 URL 문자열을 전달하는 채널.
+
+**웹뷰 측** (`src/common/flutterCommunicate.js`):
+```js
+customwebviewmessage.postMessage(url);
+```
+
+**Flutter 측** (`CustomWebViewController`):
+```dart
+webcontroller.addJavaScriptChannel(
+  'customwebviewmessage',
+  onMessageReceived: (JavaScriptMessage message) async {
+    if (await canLaunchUrl(Uri.parse(message.message))) {
+      launchUrl(Uri.parse(message.message));
+    }
+  },
+);
+```
+
+> 참고: `webtofluttermessage` 채널은 지도(HSSC/NSC 건물 맵)에서 JSON 데이터를 보내는 용도로 별도 존재.
+
+## 3. 웹뷰가 보내는 메시지 타입
+
+### 전화 걸기 (`tel:`)
+```js
+flutterCommunicate('tel:027601073')
+```
+Flutter가 `launchUrl`로 처리하면 OS 전화 다이얼러가 열림.
+
+### 네이버 지도 (`nmap://`)
+```js
+flutterCommunicate('nmap://route/walk?dlat=37.587308&dlng=126.993688&dname=...')
+```
+
+### 카카오맵 (`kakaomap://`)
+```js
+flutterCommunicate('kakaomap://route?ep=37.587308,126.993688&by=FOOT&eName=...')
+```
+
+### 애플 지도 (`maps://`)
+```js
+flutterCommunicate('maps://?t=m&daddr=37.587308,126.993688')
+```
+
+### 외부 링크 (`http://`, `https://`)
+```js
+flutterCommunicate('https://example.com')
+```
+
+> iOS `Info.plist`의 `LSApplicationQueriesSchemes`와 Android `AndroidManifest.xml`의 `<queries>`에 `tel`, `nmap`, `kakaomap` 스킴이 이미 등록되어 있어 `canLaunchUrl`이 정상 동작함.
+
+## 4. Flutter 라우트 변경 가이드
+
+기존 네이티브 정보 화면을 웹뷰로 교체하려면, "정보" 버튼의 네비게이션을 `/customwebview` 라우트로 변경한다.
+
+### 인사캠 셔틀버스 정보
+
+**변경 전** (`bus_seoul_main_screen.dart`):
+```dart
+rightBtnAction: () {
+  Get.toNamed('/MainbusDetail');
+},
+```
+
+**변경 후**:
+```dart
+rightBtnAction: () {
+  Get.toNamed('/customwebview', arguments: {
+    'title': '인사캠 셔틀버스',
+    'color': '003626',
+    'webviewLink': 'https://skkubus-webview.vercel.app/#/bus/hssc/info',
+  });
+},
+```
+
+### 인자셔틀 정보
+
+**변경 전** (`bus_inja_main_screen.dart`):
+```dart
+onTap: () => Get.toNamed('/injadetail'),
+```
+
+**변경 후**:
+```dart
+onTap: () => Get.toNamed('/customwebview', arguments: {
+  'title': '인자셔틀',
+  'color': '003626',
+  'webviewLink': 'https://skkubus-webview.vercel.app/#/bus/campus/info',
+}),
+```
+
+## 5. customwebviewmessage 핸들러 개선 (권장)
+
+현재 핸들러는 앱 미설치 시 **조용히 실패**한다 (`canLaunchUrl`이 false를 반환하면 아무 동작 없음).
+
+기존 `InjaDetailController.executeMap()`과 동일한 fallback을 추가하려면:
+
+```dart
+onMessageReceived: (JavaScriptMessage message) async {
+  final uri = Uri.parse(message.message);
+
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri);
+  } else if (uri.scheme == 'nmap' || uri.scheme == 'kakaomap') {
+    // 지도 앱 미설치 시 앱스토어/플레이스토어로 안내
+    final mapName = uri.scheme == 'nmap' ? '네이버 지도' : '카카오맵';
+    final result = await FlutterPlatformAlert.showCustomAlert(
+      windowTitle: '$mapName가 설치되어 있지 않아요',
+      text: '$mapName 설치 페이지로 이동할까요?',
+      negativeButtonTitle: '이동',
+      positiveButtonTitle: '취소',
+    );
+
+    if (result == CustomButton.negativeButton) {
+      final storeUrl = Platform.isIOS
+          ? (uri.scheme == 'nmap'
+              ? 'https://apps.apple.com/kr/app/naver-map-navigation/id311867728'
+              : 'https://apps.apple.com/kr/app/kakaomap-korea-no-1-map/id304608425')
+          : (uri.scheme == 'nmap'
+              ? 'https://play.google.com/store/apps/details?id=com.nhn.android.nmap'
+              : 'https://play.google.com/store/apps/details?id=net.daum.android.map');
+      if (await canLaunchUrl(Uri.parse(storeUrl))) {
+        await launchUrl(Uri.parse(storeUrl));
+      }
+    }
+  }
+},
+```
+
+> 필요 import: `flutter_platform_alert`, `dart:io` (Platform)
+
+## 6. 웹뷰 경로 ↔ Flutter 라우트 대응표
+
+| 웹뷰 경로 (HashRouter) | 기존 Flutter 라우트 | Flutter `customwebview` title |
+|---|---|---|
+| `#/bus/hssc/info` | `/MainbusDetail` | 인사캠 셔틀버스 |
+| `#/bus/campus/info` | `/injadetail` | 인자셔틀 |
+| `#/map/hssc` | `/hsscbuildingmap` | (별도 WebView 컨트롤러 사용) |
+| `#/map/nsc` | `/nscbuildingmap` | (별도 WebView 컨트롤러 사용) |
+| `#/bus/newyear` | `/customwebview` | (이미 웹뷰) |

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,8 @@ import "./App.css";
 import { useEffect } from "react";
 import KNewYearBus from "./pages/KNewYearBus/KNewYearBus";
 import KNewYearBusDetail from "./pages/KNewYearBus/KNewYearBusDetail";
+import HSSCBusInfo from "./pages/bus/HSSCBusInfo";
+import CampusBusInfo from "./pages/bus/CampusBusInfo";
 import { Routes, Route } from "react-router-dom";
 import ErrorPage from "./pages/error";
 import HSSCMap from "./pages/hsscmap/hsscmap";
@@ -26,6 +28,8 @@ function App() {
       <Route path="bus">
         <Route path="newyear" element={<KNewYearBus />} />
         <Route path="newyear/detail" element={<KNewYearBusDetail />} />
+        <Route path="hssc/info" element={<HSSCBusInfo />} />
+        <Route path="campus/info" element={<CampusBusInfo />} />
       </Route>
     </Routes>
   );

--- a/src/pages/bus/CampusBusInfo.js
+++ b/src/pages/bus/CampusBusInfo.js
@@ -1,0 +1,117 @@
+import React from "react";
+import flutterCommunicate from "../../common/flutterCommunicate";
+
+const seoulLat = 37.587308;
+const seoulLon = 126.993688;
+const seoulDestnameEncode =
+  "%EC%8A%A4%EA%BE%B8%EB%B2%84%EC%8A%A4%20%7C%20%EC%9D%B8%EC%82%AC%EC%BA%A0%20%EC%85%94%ED%8B%80%20%EC%9C%84%EC%B9%98";
+
+const suwonLat = 37.292345;
+const suwonLon = 126.975532;
+const suwonDestnameEncode =
+  "%EC%8A%A4%EA%BE%B8%EB%B2%84%EC%8A%A4%20%7C%20%EC%9E%90%EA%B3%BC%EC%BA%A0%20%EC%85%94%ED%8B%80%20%EC%9C%84%EC%B9%98";
+
+function MapButtons({ lat, lon, destnameEncode }) {
+  const naverUrl = `nmap://route/walk?dlat=${lat}&dlng=${lon}&dname=${destnameEncode}`;
+  const kakaoUrl = `kakaomap://route?ep=${lat},${lon}&by=FOOT&eName=${destnameEncode}`;
+  const appleUrl = `maps://?t=m&daddr=${lat},${lon}`;
+
+  return (
+    <div className="pl-1 pt-2 pb-2 space-y-2">
+      <div className="flex gap-2">
+        <button
+          onClick={() => flutterCommunicate(naverUrl)}
+          className="flex-1 py-2.5 rounded-full text-white font-bold text-sm border-none cursor-pointer"
+          style={{ backgroundColor: "#2DB400" }}
+        >
+          네이버 지도로 길찾기
+        </button>
+        <button
+          onClick={() => flutterCommunicate(kakaoUrl)}
+          className="flex-1 py-2.5 rounded-full text-black font-bold text-sm border-none cursor-pointer"
+          style={{ backgroundColor: "#FFE812" }}
+        >
+          카카오맵으로 길찾기
+        </button>
+      </div>
+      <div>
+        <button
+          onClick={() => flutterCommunicate(appleUrl)}
+          className="py-2.5 rounded-full text-white font-bold text-sm border-none cursor-pointer bg-black"
+          style={{ width: "calc(50% - 4px)" }}
+        >
+          애플 지도로 길찾기
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CampusBusInfo() {
+  return (
+    <div className="bg-white min-h-screen">
+      <div className="px-4 pt-1">
+        {/* 안내사항 */}
+        <div className="border-t border-gray-300 my-4" />
+        <div className="pl-1">
+          <p className="text-deep-green font-bold">안내사항</p>
+          <div className="text-gray-900 text-sm mt-1 pl-1 space-y-0.5">
+            <p>요금: 무료</p>
+            <p>
+              금요일에는 기존 인자셔틀 버스와 별도로
+              <br />
+              학부대학 셔틀버스가 추가운영됩니다
+            </p>
+            <p className="font-bold">
+              스꾸버스 시간표는 모든 버스 통합 시간표입니다
+            </p>
+          </div>
+        </div>
+
+        {/* 운행시간 */}
+        <div className="border-t border-gray-300 my-4" />
+        <div className="pl-1">
+          <p className="text-deep-green font-bold">운행시간</p>
+          <div className="text-gray-900 text-sm mt-1 pl-1 space-y-0.5">
+            <p>매주 금요일 출발 7시 버스는 8시 출발로 대체됩니다</p>
+            <p className="font-bold">토요일/일요일/공휴일/학교휴일 운행없음</p>
+          </div>
+        </div>
+
+        {/* 인자셔틀 위치 [인사캠 → 자과캠] */}
+        <div className="border-t border-gray-300 my-4" />
+        <div className="pl-1">
+          <p className="text-deep-green font-bold">
+            인자셔틀&nbsp;위치&nbsp;[인사캠 → 자과캠]
+          </p>
+          <p className="text-gray-900 text-sm mt-1 pl-1">
+            탑승장소 : 600주년 기념관 건너편
+          </p>
+          <MapButtons
+            lat={seoulLat}
+            lon={seoulLon}
+            destnameEncode={seoulDestnameEncode}
+          />
+        </div>
+
+        {/* 인자셔틀 위치 [자과캠 → 인사캠] */}
+        <div className="border-t border-gray-300 my-4" />
+        <div className="pl-1">
+          <p className="text-deep-green font-bold">
+            인자셔틀&nbsp;위치&nbsp;[자과캠 → 인사캠]
+          </p>
+          <p className="text-gray-900 text-sm mt-1 pl-1">
+            탑승장소 : N센터 앞
+          </p>
+          <MapButtons
+            lat={suwonLat}
+            lon={suwonLon}
+            destnameEncode={suwonDestnameEncode}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CampusBusInfo;

--- a/src/pages/bus/HSSCBusInfo.js
+++ b/src/pages/bus/HSSCBusInfo.js
@@ -1,0 +1,84 @@
+import React from "react";
+import flutterCommunicate from "../../common/flutterCommunicate";
+
+function HSSCBusInfo() {
+  return (
+    <div className="bg-white min-h-screen">
+      <div className="px-4 pt-1">
+        {/* [인사캠 → 혜화역] */}
+        <div className="border-t border-gray-300 my-4" />
+        <div className="pl-1">
+          <p className="text-deep-green font-bold">[인사캠 → 혜화역]</p>
+          <p className="text-gray-900 text-sm mt-1 pl-1">
+            농구장 → 학생회관 → 정문 → 올림픽기념국민생활관 → 혜화동우체국 →
+            혜화동로터리 → 혜화역 1번출구
+          </p>
+        </div>
+
+        {/* [혜화역 → 인사캠] */}
+        <div className="border-t border-gray-300 my-4" />
+        <div className="pl-1">
+          <p className="text-deep-green font-bold">[혜화역 → 인사캠]</p>
+          <p className="text-gray-900 text-sm mt-1 pl-1">
+            혜화역 1번출구 → 혜화동로터리 → 성균관대입구사거리 → 정문 →
+            600주년기념관
+          </p>
+        </div>
+
+        {/* 요금 및 결제수단 */}
+        <div className="border-t border-gray-300 my-4" />
+        <div className="pl-1">
+          <p className="text-deep-green font-bold">요금 및 결제수단</p>
+          <p className="text-gray-900 text-sm mt-1 pl-1 whitespace-pre-line">
+            {
+              "요금 400원\n후불교통결제 기능 일반카드, T머니/캐시비카드 사용 가능\n현금 및 회수권 사용 불가"
+            }
+          </p>
+        </div>
+
+        {/* 운행시간 */}
+        <div className="border-t border-gray-300 my-4" />
+        <div className="pl-1">
+          <p className="text-deep-green font-bold">운행시간</p>
+          <p className="text-gray-900 text-sm mt-1 pl-1 whitespace-pre-line">
+            {
+              "월~금 운행, 공휴일 운행 안함\n\n[학기중] 07:00 ~ 23:00\n[방학중] 07:00 ~ 19:00"
+            }
+          </p>
+        </div>
+
+        {/* 연락처 */}
+        <div className="border-t border-gray-300 my-4" />
+        <div className="pl-1">
+          <p className="text-deep-green font-bold">연락처 (클릭 시 전화연결)</p>
+          <div className="mt-1 pl-1 space-y-1">
+            <div className="flex items-center">
+              <span className="text-gray-900 text-sm">학생지원팀&nbsp;&nbsp;</span>
+              <button
+                onClick={() => flutterCommunicate("tel:027601073")}
+                className="bg-transparent border-none cursor-pointer p-0 text-deep-green font-bold text-sm"
+              >
+                02-760-1073
+              </button>
+            </div>
+            <div className="flex items-center">
+              <span className="text-gray-900 text-sm">
+                인사캠 관리팀&nbsp;&nbsp;
+              </span>
+              <button
+                onClick={() => flutterCommunicate("tel:027600110")}
+                className="bg-transparent border-none cursor-pointer p-0 text-deep-green font-bold text-sm"
+              >
+                02-760-0110
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t border-gray-300 my-4" />
+      </div>
+    </div>
+  );
+}
+
+export default HSSCBusInfo;


### PR DESCRIPTION
## Summary
- 인사캠 셔틀버스 정보 페이지 (`#/bus/hssc/info`) 및 인자셔틀 정보 페이지 (`#/bus/campus/info`) 웹뷰 구현
- 전화/지도 앱 연결은 기존 `flutterCommunicate` 채널 활용
- Flutter 연동 가이드 문서 (`docs/flutter-integration.md`) 추가

## Test plan
- [ ] `http://localhost:3002/#/bus/hssc/info` 렌더링 확인
- [ ] `http://localhost:3002/#/bus/campus/info` 렌더링 확인
- [ ] 전화/지도 버튼 클릭 시 콘솔 로그 확인
- [ ] 모바일 뷰포트(375px) 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)